### PR TITLE
Add String and Comment highlight groups to sample_spell.vim

### DIFF
--- a/colors/tools/sample_spell.vim
+++ b/colors/tools/sample_spell.vim
@@ -1,9 +1,19 @@
 " Usage:
-"     $ vim -Nu NONE -S colors/tools/sample_spell.vim +source\ colors/blue.vim
+"     $ vim --clean -S colors/blue.vim -S colors/tools/sample_spell.vim
 set nocompatible
 set spell
 set spelllang=en_ca
 set spellfile=colors/tools/en.utf-8.add
-syntax on
 setlocal bufhidden=wipe buftype=nofile nobuflisted noswapfile
-call setline(1, "Colour. colour (Spell Cap), color (Spell Local), couleur (Spell Rare), kolour (Spell Bad)")
+
+let s:text = "Colour. colour (Spell Cap), color (Spell Local), couleur (Spell Rare), kolour (Spell Bad)"
+
+call setline(1, "Normal:  " .. s:text)
+call setline(2, "String:  " .. s:text)
+call setline(3, "Comment: " .. s:text)
+
+syntax match sampleString "^String:.*$"
+syntax match sampleComment "^Comment:.*$"
+
+hi link sampleString String
+hi link sampleComment Comment


### PR DESCRIPTION
Spell checking if often done on text with Comment or String highlighting. Add these groups to sample_spell.vim.

I had to make some small changes to the "usage" line to make this work. I'm not entirely sure if it was necessary. Feedback welcome.