### PR TITLE
fix(check_colors): account for ?? as a comparison operator for t_Co

### DIFF
--- a/colors/tools/check_colors.vim
+++ b/colors/tools/check_colors.vim
@@ -156,7 +156,7 @@ def Test_check_colors()
     cursor(1, 1)
 
     # 4) Check, that t_Co is checked
-    var pat = '[&]t_Co\s*[<>=]=\?\s*\d\+'
+    var pat = '[&]t_Co\s*\%(\%([<>=]=\?\)\|??\)\s*\d\+'
     if search(pat, 'ncW') == 0
         err['t_Co'] = 'Does not check terminal for capable colors'
     endif


### PR DESCRIPTION
Colortemplate now uses `??` when checking the value of `t_Co`, which makes `check_colors.vim` complain. This PR fixes that.