### PR TITLE
Add some ScreenShots

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
+Table of Contents
+=================
+
+* [Vim's colorscheme incubator](#vims-colorscheme-incubator)
+   * [What is our mission?](#what-is-our-mission)
+      * [Adding new colorschemes](#adding-new-colorschemes)
+      * [Improving existing colorschemes](#improving-existing-colorschemes)
+      * [Providing better tooling and documentation to authors](#providing-better-tooling-and-documentation-to-authors)
+   * [What is the plan?](#what-is-the-plan)
+   * [Show me](#show-me)
+   * [Who is in charge?](#who-is-in-charge)
+   * [Install](#install)
+   * [Useful links](#useful-links)
+   * [Legacy](#legacy)
+
+<!-- Created by https://github.com/ekalinin/github-markdown-toc -->
+
 # Vim's colorscheme incubator
 
 As of 8.2, the collection of 18 colorschemes packaged with Vim (19 for MacVim) has been mostly stale for many years. In the mean time, two trends have been going strong, one fueling the other:
@@ -43,6 +60,10 @@ Such goals can't be reached without providing colorscheme authors with a solid t
 2. Find the resources and build the necessary tools.
 3. Open a proper "call for colorschemes".
 4. Include the approved submissions in the Vim distribution, either one by one or as a whole.
+
+## Show me
+
+Have a look at the [gallery](ScreenShots.md)
 
 ## Who is in charge?
 

--- a/ScreenShots.md
+++ b/ScreenShots.md
@@ -1,5 +1,9 @@
+# Screenshots
 
-# Let's show some screenshots:
+## Filetypes
+- [Vim9 File](#vim9-file)
+- [Python File](#python-file)
+- [C File](#c-file)
 
 ## Tooling
 All screenshots were made with putty, in a 29x107 size large terminal with a dark backround (configured with termguicolors or 256 colors).
@@ -177,7 +181,7 @@ putty with 'termguicolors'
 putty without 'termguicolors' and 256 colors
 ![grafik](https://user-images.githubusercontent.com/244927/226845083-d2fdb010-4db7-4865-a671-20dd3aa378e1.png)
 
-# Python Files
+# Python File
 Displaying [test_channel.py](https://github.com/vim/vim/blob/890c77203637626b1005db818667084d11e653e7/src/testdir/test_channel.py)
 
 ## [blue](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/blue.vim)
@@ -392,3 +396,178 @@ putty with 'termguicolors'
 putty without 'termguicolors' and 256 colors
 ![grafik](https://user-images.githubusercontent.com/244927/226850837-4da6c7c5-133a-4810-9f6b-396321b5e069.png)
 
+
+# C File
+Displaying [diff.c](https://github.com/vim/vim/blob/3ea62381c527395ae701715335776f427d22eb7b/src/diff.c#L102-L130))
+
+## [blue](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/blue.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/227453333-48c7b832-07bd-4ff2-bc77-a8c5c68d36c7.png)
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/227454448-f22f4225-609f-4569-88e6-d14fad603f7e.png)
+
+## [darkblue](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/darkblue.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/227453375-72755a33-0a1b-4358-9f9a-1c6a9a99267b.png)
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/227454485-e8cd647b-80fd-47cd-8663-2c5a75a69281.png)
+
+## [delek](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/delek.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/227453403-a17e8188-9172-4b93-a67d-b34bf5acbb46.png)
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/227454521-1f61ff64-44dc-4f51-b590-38dfd51b36b4.png)
+
+## [desert](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/desert.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/227453435-66cab533-522f-4a27-9dfd-dd27c60bb84b.png)
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/227454558-6ce1c21b-1c2a-453c-b7a5-35f7ec87c8f2.png)
+
+
+## [elflord](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/elflord.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/227453469-7fc73382-5d87-4926-8ce8-08be50bfd685.png)
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/227454596-97616756-064a-4bd8-84c2-f56d24a0eac2.png)
+
+
+## [evening](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/evening.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/227453501-dc9a192a-c318-4348-94be-e0b91d45e40b.png)
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/227454613-2e514500-e0b0-492c-b9fa-fb5f75cc4480.png)
+
+## [habamax](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/habamax.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/227453541-9dafdaaf-acac-4401-91cc-046ae44f8a1a.png)
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/227454662-d084dcda-7197-44f9-9291-7d543141f8e8.png)
+
+## [industry](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/industry.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/227453570-8ea12e88-5d15-47da-a4aa-95b54f4273c9.png)
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/227454693-342737ed-6b3d-49ee-a394-c7f2689d4abb.png)
+
+
+## [koehler](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/koehler.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/227453590-a682174f-2d49-41c6-9039-66e411b0f279.png)
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/227454722-9c2b40f4-033f-4a40-a668-c40769cc462e.png)
+
+## [lunaperch](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/lunaperch.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/227453617-853961b8-a1c5-488c-a9a3-e8abeca105cf.png)
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/227454752-7d5eff06-04b8-4cde-aba6-e093c10eeadf.png)
+
+
+## [morning](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/morning.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/227453645-5febf877-d458-44ae-aa52-ae79475d10a5.png)
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/227454787-19e0dc20-2b02-45de-a60e-3f71390698ee.png)
+
+## [murphy](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/murphy.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/227453661-e07e0ccd-143e-47c6-bd82-306c538be2ff.png)
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/227454819-498946af-261a-4adc-80ef-7457613a0d89.png)
+
+## [pablo](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/pablo.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/227453685-cc7cd8be-50e9-49dd-9783-4879a1ca08cd.png)
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/227454847-a0ca37f6-83e0-43ac-8e40-fa44ec50b1de.png)
+
+## [peachpuff](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/peachpuff.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/227453716-923642e2-d671-4350-ac63-a24bc771ed66.png)
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/227454876-c711f3aa-f972-4688-96c3-144c634a4bda.png)
+
+## [quiet](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/quiet.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/227453746-aa77eeef-6864-4f84-984d-33639b6035b5.png)
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/227454912-0308b490-bed9-4554-b603-1abe4ec0e096.png)
+
+## [retrobox](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/retrobox.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/227453766-2ba3e3b3-b51f-4a1f-89c7-f7b18a3f865b.png)
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/227454944-32c04d8c-0249-4c61-bc83-003d7db9ee8c.png)
+
+## [ron](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/ron.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/227453793-40b5b087-90b8-489b-8a34-cab07acf9d9c.png)
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/227454984-bf6be42e-2f36-4517-8801-236a45533aea.png)
+
+## [shine](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/shine.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/227453822-4bf2c57e-42ad-4862-b332-89e3f3e51572.png)
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/227455022-3cbf73d7-c7d6-4b5b-b61e-2635b725ebfa.png)
+
+## [slate](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/slate.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/227453940-2d97934e-e55f-4be9-933c-33ed26fc64cf.png)
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/227455042-620a7d1f-3221-43f4-a9d8-0569c23ae8e3.png)
+
+## [sorbet](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/sorbet.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/227454294-ddb184df-b5fe-469e-9783-237ecd2abe6c.png)
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/227455075-ef82fae2-9beb-487b-ab66-d1f8fba0117c.png)
+
+## [torte](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/torte.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/227453993-afe54956-e895-4078-857e-7a31f6687f88.png)
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/227455098-8efdf8da-8809-40a3-99c7-53c427590fb0.png)
+
+## [wildcharm](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/wildcharm.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/227454015-f205d221-20a1-4565-a3ce-57bbb07c3a7c.png)
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/227455134-a40476c2-34fb-4d1d-be48-10498a64769f.png)
+
+## [zaibatsu](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/zaibatsu.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/227454046-e419a237-7756-4d9d-aa61-9e00e93a013e.png)
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/227455166-1c147973-677c-459c-b344-9756514a0248.png)
+
+## [zellner](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/zellner.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/227454070-176a673e-7e6d-491e-9a84-5af05c920402.png)
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/227455203-b78ca46b-28ca-4356-b7ca-270f1932a7c4.png)

--- a/ScreenShots.md
+++ b/ScreenShots.md
@@ -15,172 +15,171 @@ Displaying [check_colors.vim](https://github.com/vim/colorschemes/blob/c8f5b1f04
 
 ## [blue](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/blue.vim)
 putty with 'termguicolors'
-![grafik](https://user-images.githubusercontent.com/244927/226674769-6d69a424-a87a-44b6-965e-9c9584b4e1d7.png)
+![grafik](![grafik](https://user-images.githubusercontent.com/244927/228226998-4c9e231d-17c5-41ba-86e5-2df78b20e1e1.png))
 
 putty without 'termguicolors' and 256 colors
-![grafik](https://user-images.githubusercontent.com/244927/226842696-62febd29-9eec-4ad9-86e7-eb1c2ba9a0e3.png)
+![grafik](https://user-images.githubusercontent.com/244927/228231739-9fe967ea-1549-484c-a8fa-5f734a147e89.png)
 
 ## [darkblue](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/darkblue.vim)
 putty with 'termguicolors'
-![grafik](https://user-images.githubusercontent.com/244927/226674886-ee590186-ac57-41fd-a42f-ad2823a705e3.png)
+![grafik](https://user-images.githubusercontent.com/244927/228227245-31414d3b-a897-4902-b150-3cbe5066c2da.png)
 
 putty without 'termguicolors' and 256 colors
-![grafik](https://user-images.githubusercontent.com/244927/226843553-a27c203f-3c17-42a8-909f-4859e01417d5.png)
+![grafik](https://user-images.githubusercontent.com/244927/228231799-12b1d42d-54d8-4203-9dda-0d0ca6ca7b4d.png)
 
 ## [delek](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/delek.vim)
 putty with 'termguicolors' and 'light' background
-![grafik](https://i.imgur.com/fIxcOit.png)
+![grafik](https://user-images.githubusercontent.com/244927/228229972-50784127-5167-4981-83b7-120d831705d6.png)
 
 putty without 'termguicolors' and 256 colors and 'light' background
-![grafik](https://i.imgur.com/2NadD2Y.png)
+![grafik](https://user-images.githubusercontent.com/244927/228231175-08030a75-33e9-4d92-a297-ee8c2380e64a.png)
 
 ## [desert](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/desert.vim)
 putty with 'termguicolors'
-![grafik](https://user-images.githubusercontent.com/244927/226675186-b4d1bb19-afdd-471a-97e0-8797c2a085f9.png)
+![grafik](https://user-images.githubusercontent.com/244927/228227338-10240e85-0657-49b0-a815-8c55b951653c.png)
 
 putty without 'termguicolors' and 256 colors
-![grafik](https://user-images.githubusercontent.com/244927/226843661-33afe7e8-2d9b-4262-bd1a-3e9d7a4b524d.png)
+![grafik](https://user-images.githubusercontent.com/244927/228231932-e12ee1e1-8fae-4f57-b06a-affd21768704.png)
 
 ## [elflord](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/elflord.vim)
 putty with 'termguicolors'
-![grafik](https://user-images.githubusercontent.com/244927/226675509-bf88ab9b-26e1-41ad-969b-0e8203408afb.png)
+![grafik](https://user-images.githubusercontent.com/244927/228227419-cd3d8357-f8c1-4cf4-8658-f8dc855f19dd.png)
 
 putty without 'termguicolors' and 256 colors
-![grafik](https://user-images.githubusercontent.com/244927/226843727-2a36bad6-6e21-4691-9e88-aa563719c87c.png)
+![grafik](https://user-images.githubusercontent.com/244927/228231994-4ddf1aab-3505-4ec1-9238-0f5fafca6a38.png)
 
 ## [evening](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/evening.vim)
 putty with 'termguicolors'
-![grafik](https://user-images.githubusercontent.com/244927/226675647-9ee5133d-70dc-449a-997e-ac29ea196d03.png)
+![grafik](https://user-images.githubusercontent.com/244927/228227467-e301a486-e97c-4693-b574-0739874e9b00.png)
 
 putty without 'termguicolors' and 256 colors
-![grafik](https://user-images.githubusercontent.com/244927/226843778-b271e77c-6f95-4eaf-be67-da9cc1ca17da.png)
+![grafik](https://user-images.githubusercontent.com/244927/228232031-7c6ffada-1872-4749-8886-cd903d297198.png)
 
 ## [habamax](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/habamax.vim)
 putty with 'termguicolors'
-![grafik](https://user-images.githubusercontent.com/244927/226675967-935b4737-7578-412b-b766-18cd223b5f8f.png)
+![grafik](https://user-images.githubusercontent.com/244927/228227512-fcb78010-61f7-4a30-8f0a-840ebcc8965f.png)
 
 putty without 'termguicolors' and 256 colors
-![grafik](https://user-images.githubusercontent.com/244927/226843826-7f9452fa-0745-4ae6-8c9f-51b5517da5d8.png)
-
+![grafik](https://user-images.githubusercontent.com/244927/228232069-ec658590-404e-4972-ad10-a9da482733c9.png)
 
 ## [industry](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/industry.vim)
 putty with 'termguicolors'
-![grafik](https://user-images.githubusercontent.com/244927/226676104-7598a515-4738-44be-8e85-dd9799980ad6.png)
+![grafik](https://user-images.githubusercontent.com/244927/228227571-73bca3dd-0d7a-4f1e-8e28-8649d6347541.png)
 
 putty without 'termguicolors' and 256 colors
-![grafik](https://user-images.githubusercontent.com/244927/226843879-a36c5e6f-8685-400f-9182-454d4dbfe6dd.png)
+![grafik](https://user-images.githubusercontent.com/244927/228232108-847825a8-be5c-447a-b4b3-7e858a05819d.png)
 
 ## [koehler](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/koehler.vim)
 putty with 'termguicolors'
-![grafik](https://user-images.githubusercontent.com/244927/226676243-2511c865-410b-420a-a21f-08f5274beff0.png)
+![grafik](https://user-images.githubusercontent.com/244927/228227643-9a0d8102-5562-4588-9720-aed9a429fb71.png)
 
 putty without 'termguicolors' and 256 colors
-![grafik](https://user-images.githubusercontent.com/244927/226843935-52ff27a9-4065-482e-9cc2-9bdc6342e461.png)
+![grafik](https://user-images.githubusercontent.com/244927/228232159-51187730-8ad6-4ac6-9f3d-e82d2f2e169f.png)
 
 ## [lunaperch](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/lunaperch.vim)
 putty with 'termguicolors'
-![grafik](https://user-images.githubusercontent.com/244927/226676420-b889d005-f7ad-48f7-aa84-5f90b7920fcb.png)
+![grafik](https://user-images.githubusercontent.com/244927/228227693-3afc2153-d04c-43ed-932a-96a460683653.png)
 
 putty without 'termguicolors' and 256 colors
-![grafik](https://user-images.githubusercontent.com/244927/226843971-82f34c20-4ce0-44d8-8b5f-c457c3e371e5.png)
+![grafik](https://user-images.githubusercontent.com/244927/228232240-bfa4af27-da63-479f-bd0f-356cef444fa7.png)
 
 ## [morning](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/morning.vim)
 putty with 'termguicolors' and 'light' background
-![grafik](https://i.imgur.com/Kn0O6Om.png)
+![grafik](https://user-images.githubusercontent.com/244927/228230046-300e6b6b-384c-4609-8c4d-d2a5ac68c78c.png)
 
-putty without 'termguicolors' and 256 colors and 'ligth' background
-![grafik](https://i.imgur.com/FnIb16o.png)
+putty without 'termguicolors' and 256 colors and 'light' background
+![grafik](https://user-images.githubusercontent.com/244927/228231237-cad7f099-7811-433a-ae2c-7b9dca77b783.png)
 
 ## [murphy](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/murphy.vim)
 putty with 'termguicolors'
-![grafik](https://user-images.githubusercontent.com/244927/226676750-af7db29b-3d5b-4d0f-a3dd-ac4b2cc38235.png)
+![grafik](https://user-images.githubusercontent.com/244927/228227776-dbb6d8ef-33e5-4b76-b5e3-a68383785fc4.png)
 
 putty without 'termguicolors' and 256 colors
-![grafik](https://user-images.githubusercontent.com/244927/226844059-642728a7-f688-4e3d-b0d4-34552dae6af8.png)
+![grafik](https://user-images.githubusercontent.com/244927/228232275-7fb92f45-5028-46f5-b265-c52cf3525d00.png)
 
 ## [pablo](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/pablo.vim)
 putty with 'termguicolors'
-![grafik](https://user-images.githubusercontent.com/244927/226676918-503c1455-7877-404c-97e1-f656fd095d27.png)
+![grafik](https://user-images.githubusercontent.com/244927/228227822-6d835982-e62b-43a5-bfd9-05fef8e72ce0.png)
 
 putty without 'termguicolors' and 256 colors
-![grafik](https://user-images.githubusercontent.com/244927/226844117-fbaae4ca-afdb-4104-aacf-a5d3ca88a230.png)
+![grafik](https://user-images.githubusercontent.com/244927/228232316-1a9f1758-7368-4628-8633-7beda91f42fd.png)
 
 ## [peachpuff](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/peachpuff.vim)
 putty with 'termguicolors' and 'light' background
-![grafik](https://i.imgur.com/kP9yqBR.png)
+![grafik](https://user-images.githubusercontent.com/244927/228230073-7b22f324-3eee-4580-8a43-5b720ad11c3e.png)
 
 putty without 'termguicolors' and 256 colors and 'light' background
-![grafik](https://i.imgur.com/1h20sBy.png)
+![grafik](https://user-images.githubusercontent.com/244927/228231308-93fc470e-15f0-4075-b10c-cc004764535a.png)
 
 ## [quiet](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/quiet.vim)
 putty with 'termguicolors'
-![grafik](https://user-images.githubusercontent.com/244927/226677247-c2adef84-8d3a-49cf-898e-35b2cecb787d.png)
+![grafik](https://user-images.githubusercontent.com/244927/228227848-3b3572b4-0bcc-46ad-92da-bd40f2699ba1.png)
 
 putty without 'termguicolors'
-![grafik](https://user-images.githubusercontent.com/244927/226844239-35d18954-fcaf-453b-8f44-4a19e20ac305.png)
+![grafik](https://user-images.githubusercontent.com/244927/228232351-7481822d-bd04-48ec-a68e-3c1e21b71017.png)
 
 ## [retrobox](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/retrobox.vim)
 putty with 'termguicolors'
-![grafik](https://user-images.githubusercontent.com/244927/226677397-02196d0c-4297-472f-98c4-4d9d2ac3fafb.png)
+![grafik](https://user-images.githubusercontent.com/244927/228227893-483ee148-6324-4d41-867f-cbcc2df09ad6.png)
 
 putty without 'termguicolors' and 256 colors
-![grafik](https://user-images.githubusercontent.com/244927/226844296-8e91a260-b7ca-4f40-91ff-c621d9e54c6f.png)
+![grafik](https://user-images.githubusercontent.com/244927/228232397-7b70fa5c-cb65-4d6f-94be-f34d770080a6.png)
 
 ## [ron](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/ron.vim)
 putty with 'termguicolors'
-![grafik](https://user-images.githubusercontent.com/244927/226677520-62509ecf-dfd9-40eb-bb8c-593f842a9f32.png)
+![grafik](https://user-images.githubusercontent.com/244927/228227936-73c46bfd-fbb0-411a-a6e0-c6e0cc93662b.png)
 
 putty without 'termguicolors' and 256 colors
-![grafik](https://user-images.githubusercontent.com/244927/226844368-5bccade8-8b04-4e20-9ca3-b7ce5ce31b1a.png)
+![grafik](https://user-images.githubusercontent.com/244927/228232466-ae924a45-18fc-4370-a58a-903ad8db260e.png)
 
 ## [shine](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/shine.vim)
 putty with 'termguicolors' and 'light' background
-![grafik](https://i.imgur.com/8BHR90d.png)
+![grafik](https://user-images.githubusercontent.com/244927/228230139-9c5210dd-3527-4e22-9ac1-ae6833d2ce86.png)
 
 putty without 'termguicolors' and 256 colors and 'light' background
-![grafik](https://imgur.com/0Mjfcm1.png)
+![grafik](https://user-images.githubusercontent.com/244927/228231356-d77f4109-682d-4005-a3d7-88c774326dfa.png)
 
 ## [slate](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/slate.vim)
 putty with 'termguicolors'
-![grafik](https://user-images.githubusercontent.com/244927/226677764-483652b9-5bc5-4832-9b75-028135f1bf10.png)
+![grafik](https://user-images.githubusercontent.com/244927/228227970-24bf79ee-211b-4655-8363-00530eda4f0a.png)
 
 putty without 'termguicolors' and 256 colors
-![grafik](https://user-images.githubusercontent.com/244927/226844552-2363dcc9-639e-4916-a339-497b87032899.png)
+![grafik](https://user-images.githubusercontent.com/244927/228232507-1f489015-0fa7-4a4c-b06d-75aaf4d8efbb.png)
 
 ## [sorbet](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/sorbet.vim)
 putty with 'termguicolors'
-![grafik](https://user-images.githubusercontent.com/244927/226677896-5dab2a0a-ceb2-4e3b-88df-1e7f922a0e74.png)
+![grafik](https://user-images.githubusercontent.com/244927/228228048-ce448cc3-6e95-44a2-832d-c48f41da0d16.png)
 
 putty without 'termguicolors' and 256 colors
-![grafik](https://user-images.githubusercontent.com/244927/226844644-ae8ade37-6d4a-4801-a4e1-f3a6594e3ebe.png)
+![grafik](https://user-images.githubusercontent.com/244927/228232544-02b8cc80-5459-48ef-983a-2178fcd80048.png)
 
 ## [torte](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/torte.vim)
 putty with 'termguicolors'
-![grafik](https://user-images.githubusercontent.com/244927/226677994-d07cb4a3-2436-4909-a7cb-dcbaf71e535a.png)
+![grafik](https://user-images.githubusercontent.com/244927/228228093-34aa2d73-9b1b-4e79-832b-fc34a7fd5b2d.png)
 
 putty without 'termguicolors' and 256 colors
-![grafik](https://user-images.githubusercontent.com/244927/226844809-e293829e-0881-4d0d-9d20-699ffa882dba.png)
+![grafik](https://user-images.githubusercontent.com/244927/228232576-c29d6bc5-92ce-432d-bcb2-3eb1281bb70e.png)
 
 ## [wildcharm](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/wildcharm.vim)
 putty with 'termguicolors'
-![grafik](https://user-images.githubusercontent.com/244927/226678080-40adf59e-1b9b-48bc-aac2-3551e6fb69ba.png)
+![grafik](https://user-images.githubusercontent.com/244927/228228175-1befb3e3-7e4b-4d17-a8a5-6f68224b2813.png)
 
 putty without 'termguicolors' and 256 colors
-![grafik](https://user-images.githubusercontent.com/244927/226844911-f21f1bb6-751f-4ea0-ad45-5654ef200cff.png)
+![grafik](https://user-images.githubusercontent.com/244927/228232618-59ab6c93-fbc6-456c-8ac8-681deea24fa6.png)
 
 ## [zaibatsu](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/zaibatsu.vim)
 putty with 'termguicolors'
-![grafik](https://user-images.githubusercontent.com/244927/226678222-4efc274f-b774-4783-a69b-085588d3c3e1.png)
+![grafik](https://user-images.githubusercontent.com/244927/228228215-9d8ae4cc-88da-43e8-808f-6e78fedc7df4.png)
 
 putty without 'termguicolors' and 256 colors
-![grafik](https://user-images.githubusercontent.com/244927/226844986-d181ebff-4375-4d5f-bd7e-a6f04ecfa744.png)
+![grafik](https://user-images.githubusercontent.com/244927/228232660-d0d30e3d-9436-4843-b76d-d9123cd8482e.png)
 
 ## [zellner](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/zellner.vim)
 putty with 'termguicolors' and 'light' background
-![grafik](https://i.imgur.com/xx2kxUL.png)
+![grafik](https://user-images.githubusercontent.com/244927/228230187-ef019fe6-907e-4e0f-b95c-5f4d83ec7227.png)
 
 putty without 'termguicolors' and 256 colors and 'light' background
-![grafik](https://imgur.com/KmQpuuN.png)
+![grafik](https://user-images.githubusercontent.com/244927/228231404-1ded5452-f1cf-4b44-904c-816db7cde0f8.png)
 
 # Python File
 Displaying [test_channel.py](https://github.com/vim/vim/blob/890c77203637626b1005db818667084d11e653e7/src/testdir/test_channel.py)

--- a/ScreenShots.md
+++ b/ScreenShots.md
@@ -28,11 +28,11 @@ putty without 'termguicolors' and 256 colors
 ![grafik](https://user-images.githubusercontent.com/244927/226843553-a27c203f-3c17-42a8-909f-4859e01417d5.png)
 
 ## [delek](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/delek.vim)
-putty with 'termguicolors'
-![grafik](https://user-images.githubusercontent.com/244927/226674977-319167f3-5ce7-4a46-a625-95f6e30215e4.png)
+putty with 'termguicolors' and 'light' background
+![grafik](https://i.imgur.com/fIxcOit.png)
 
-putty without 'termguicolors' and 256 colors
-![grafik](https://user-images.githubusercontent.com/244927/226843607-b6ad101d-f96c-4256-82ae-e4fbe7fe1bd0.png)
+putty without 'termguicolors' and 256 colors and 'light' background
+![grafik](https://i.imgur.com/2NadD2Y.png)
 
 ## [desert](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/desert.vim)
 putty with 'termguicolors'
@@ -85,11 +85,11 @@ putty without 'termguicolors' and 256 colors
 ![grafik](https://user-images.githubusercontent.com/244927/226843971-82f34c20-4ce0-44d8-8b5f-c457c3e371e5.png)
 
 ## [morning](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/morning.vim)
-putty with 'termguicolors'
-![grafik](https://user-images.githubusercontent.com/244927/226676609-8c3a5ef8-c2f7-4bcc-8f2e-8dc41d9c54a5.png)
+putty with 'termguicolors' and 'light' background
+![grafik](https://i.imgur.com/Kn0O6Om.png)
 
-putty without 'termguicolors' and 256 colors
-![grafik](https://user-images.githubusercontent.com/244927/226844020-afa7ab35-ab0e-4be5-a2e4-ef2dbe65fc16.png)
+putty without 'termguicolors' and 256 colors and 'ligth' background
+![grafik](https://i.imgur.com/FnIb16o.png)
 
 ## [murphy](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/murphy.vim)
 putty with 'termguicolors'
@@ -106,11 +106,11 @@ putty without 'termguicolors' and 256 colors
 ![grafik](https://user-images.githubusercontent.com/244927/226844117-fbaae4ca-afdb-4104-aacf-a5d3ca88a230.png)
 
 ## [peachpuff](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/peachpuff.vim)
-putty with 'termguicolors'
-![grafik](https://user-images.githubusercontent.com/244927/226677023-be845a95-d627-495c-92f1-d37c08e34387.png)
+putty with 'termguicolors' and 'light' background
+![grafik](https://i.imgur.com/kP9yqBR.png)
 
-putty without 'termguicolors' and 256 colors
-![grafik](https://user-images.githubusercontent.com/244927/226844161-aaf3b43b-664d-444c-996d-916ccc3564cc.png)
+putty without 'termguicolors' and 256 colors and 'light' background
+![grafik](https://i.imgur.com/1h20sBy.png)
 
 ## [quiet](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/quiet.vim)
 putty with 'termguicolors'
@@ -134,11 +134,11 @@ putty without 'termguicolors' and 256 colors
 ![grafik](https://user-images.githubusercontent.com/244927/226844368-5bccade8-8b04-4e20-9ca3-b7ce5ce31b1a.png)
 
 ## [shine](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/shine.vim)
-putty with 'termguicolors'
-![grafik](https://user-images.githubusercontent.com/244927/226677637-422a4da1-a976-42a7-8c5d-d449c96d6607.png)
+putty with 'termguicolors' and 'light' background
+![grafik](https://i.imgur.com/8BHR90d.png)
 
-putty without 'termguicolors' and 256 colors
-![grafik](https://user-images.githubusercontent.com/244927/226844451-e0b808b3-3291-4dd6-9978-652f571875fe.png)
+putty without 'termguicolors' and 256 colors and 'light' background
+![grafik](https://imgur.com/0Mjfcm1.png)
 
 ## [slate](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/slate.vim)
 putty with 'termguicolors'
@@ -176,11 +176,11 @@ putty without 'termguicolors' and 256 colors
 ![grafik](https://user-images.githubusercontent.com/244927/226844986-d181ebff-4375-4d5f-bd7e-a6f04ecfa744.png)
 
 ## [zellner](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/zellner.vim)
-putty with 'termguicolors'
-![grafik](https://user-images.githubusercontent.com/244927/226678374-28318b04-9e5c-41a9-a6ec-d453a40e1a93.png)
+putty with 'termguicolors' and 'light' background
+![grafik](https://i.imgur.com/xx2kxUL.png)
 
-putty without 'termguicolors' and 256 colors
-![grafik](https://user-images.githubusercontent.com/244927/226845083-d2fdb010-4db7-4865-a671-20dd3aa378e1.png)
+putty without 'termguicolors' and 256 colors and 'light' background
+![grafik](https://imgur.com/KmQpuuN.png)
 
 # Python File
 Displaying [test_channel.py](https://github.com/vim/vim/blob/890c77203637626b1005db818667084d11e653e7/src/testdir/test_channel.py)
@@ -200,13 +200,11 @@ putty without 'termguicolors' and 256 colors
 ![grafik](https://user-images.githubusercontent.com/244927/226849849-3b382a2f-b88a-4694-97c3-7f17288d1d0c.png)
 
 ## [delek](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/delek.vim)
-putty with 'termguicolors'
-![grafik](https://user-images.githubusercontent.com/244927/226851106-7dc7f3eb-dbf1-4a17-bd21-c107a96fee4e.png)
+putty with 'termguicolors' and 'light' background
+![grafik](https://i.imgur.com/RYqNReq.png)
 
-
-putty without 'termguicolors' and 256 colors
-![grafik](https://user-images.githubusercontent.com/244927/226849905-224dc9d9-a3d5-4599-9458-ad42641d364e.png)
-
+putty without 'termguicolors' and 256 colors and 'light' background
+![grafik](https://i.imgur.com/O2YAJJS.png)
 
 ## [desert](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/desert.vim)
 putty with 'termguicolors'
@@ -273,129 +271,102 @@ putty without 'termguicolors' and 256 colors
 
 
 ## [morning](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/morning.vim)
-putty with 'termguicolors'
-![grafik](https://user-images.githubusercontent.com/244927/226851393-52027639-ea4f-4ee0-93f0-192d1c43f3b9.png)
+putty with 'termguicolors' and 'light' background
+![grafik](https://i.imgur.com/bH3a0jA.png)
 
-
-putty without 'termguicolors' and 256 colors
-![grafik](https://user-images.githubusercontent.com/244927/226850265-0e6c482a-f75a-4359-8886-7adcf1738f01.png)
-
+putty without 'termguicolors' and 256 colors and 'light' background
+![grafik](https://i.imgur.com/roI1EF7.png)
 
 ## [murphy](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/murphy.vim)
 putty with 'termguicolors'
 ![grafik](https://user-images.githubusercontent.com/244927/226851420-879d1598-09c8-4cf4-842a-076c6a9ec804.png)
 
-
 putty without 'termguicolors' and 256 colors
 ![grafik](https://user-images.githubusercontent.com/244927/226850346-26dd4f00-0e9a-41e4-b9c0-0a8a711fba19.png)
-
 
 ## [pablo](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/pablo.vim)
 putty with 'termguicolors'
 ![grafik](https://user-images.githubusercontent.com/244927/226851456-38b3b874-4336-414f-a302-46acd8e090fb.png)
 
-
 putty without 'termguicolors' and 256 colors
 ![grafik](https://user-images.githubusercontent.com/244927/226850367-13dc72d8-b782-4e01-a166-2a0cc3d156d2.png)
 
-
 ## [peachpuff](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/peachpuff.vim)
-putty with 'termguicolors'
-![grafik](https://user-images.githubusercontent.com/244927/226851491-78ef2f0e-9f80-44c9-8d8e-61f4f4217818.png)
+putty with 'termguicolors' and 'light' background
+![grafik](https://i.imgur.com/C7u5xXm.png)
 
-
-putty without 'termguicolors' and 256 colors
-![grafik](https://user-images.githubusercontent.com/244927/226850398-3ce6004b-4462-484f-995c-8f4c9369120a.png)
-
+putty without 'termguicolors' and 256 colors and 'light' background
+![grafik](https://i.imgur.com/EEMuCbG.png)
 
 ## [quiet](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/quiet.vim)
 putty with 'termguicolors'
 ![grafik](https://user-images.githubusercontent.com/244927/226851534-2b857a25-94a8-4e6b-bf6a-a783315ead2d.png)
 
-
 putty without 'termguicolors' and 256 colors
 ![grafik](https://user-images.githubusercontent.com/244927/226850424-a04919ae-74b7-40dd-8988-b49c2dadcad5.png)
-
 
 ## [retrobox](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/retrobox.vim)
 putty with 'termguicolors'
 ![grafik](https://user-images.githubusercontent.com/244927/226851555-2a8fb08c-8da2-4832-b25b-c493d90379d6.png)
 
-
 putty without 'termguicolors' and 256 colors
 ![grafik](https://user-images.githubusercontent.com/244927/226850468-4b33621a-0001-4b59-84ea-061333f24c98.png)
-
 
 ## [ron](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/ron.vim)
 putty with 'termguicolors'
 ![grafik](https://user-images.githubusercontent.com/244927/226851598-b245c3c3-ce57-482e-8d47-3df84d6dc63d.png)
 
-
 putty without 'termguicolors' and 256 colors
 ![grafik](https://user-images.githubusercontent.com/244927/226850507-a1600b7c-2f4d-48fe-b577-607ae4411c34.png)
 
-
 ## [shine](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/shine.vim)
-putty with 'termguicolors'
-![grafik](https://user-images.githubusercontent.com/244927/226851622-545ccf29-06a1-41ff-a318-f04b3cf3ed6e.png)
+putty with 'termguicolors' and 'light' background
+![grafik](https://i.imgur.com/jkicnx1.png)
 
-
-putty without 'termguicolors' and 256 colors
-![grafik](https://user-images.githubusercontent.com/244927/226850569-9011750b-bf17-4605-9d09-7e3f2c947b0f.png)
-
+putty without 'termguicolors' and 256 colors and 'light' background
+![grafik](https://i.imgur.com/0lG9hD1.png)
 
 ## [slate](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/slate.vim)
 putty with 'termguicolors'
 ![grafik](https://user-images.githubusercontent.com/244927/226851658-e2ed398b-6373-4451-b22a-eadbfbce927c.png)
 
-
 putty without 'termguicolors' and 256 colors
 ![grafik](https://user-images.githubusercontent.com/244927/226850612-66d1af4c-dd52-4111-a70a-cc9111f0ab40.png)
-
 
 ## [sorbet](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/sorbet.vim)
 putty with 'termguicolors'
 ![grafik](https://user-images.githubusercontent.com/244927/226851680-10f78c80-edc2-403c-acc3-603546929a9e.png)
 
-
 putty without 'termguicolors' and 256 colors
 ![grafik](https://user-images.githubusercontent.com/244927/226850661-ac4345d4-0b63-424c-b2dc-9e9cc4b3420c.png)
-
 
 ## [torte](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/torte.vim)
 putty with 'termguicolors'
 ![grafik](https://user-images.githubusercontent.com/244927/226851715-3916ee4c-587e-4adf-9b5e-ffe9a79c4c2b.png)
 
-
 putty without 'termguicolors' and 256 colors
 ![grafik](https://user-images.githubusercontent.com/244927/226850712-4020ce24-97c4-453e-b0a7-e7c090310b06.png)
-
 
 ## [wildcharm](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/wildcharm.vim)
 putty with 'termguicolors'
 ![grafik](https://user-images.githubusercontent.com/244927/226851747-fa7e4815-7a1d-4ce8-8139-3f227776c12b.png)
 
-
 putty without 'termguicolors' and 256 colors
 ![grafik](https://user-images.githubusercontent.com/244927/226850760-52bf8537-bcfe-44a5-a61a-c363fcdf11eb.png)
-
 
 ## [zaibatsu](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/zaibatsu.vim)
 putty with 'termguicolors'
 ![grafik](https://user-images.githubusercontent.com/244927/226851769-20c27625-11a4-4dd8-ba6e-690e1d0b199e.png)
 
-
 putty without 'termguicolors' and 256 colors
 ![grafik](https://user-images.githubusercontent.com/244927/226850800-7b854bce-995f-4e5e-a961-0ecbb6a30867.png)
 
-
 ## [zellner](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/zellner.vim)
-putty with 'termguicolors'
-![grafik](https://user-images.githubusercontent.com/244927/226851809-bc94c0a6-de63-4519-af09-3cd3589e3fb8.png)
+putty with 'termguicolors' and 'light' background
+![grafik](https://i.imgur.com/JMKMSky.png)
 
-
-putty without 'termguicolors' and 256 colors
-![grafik](https://user-images.githubusercontent.com/244927/226850837-4da6c7c5-133a-4810-9f6b-396321b5e069.png)
+putty without 'termguicolors' and 256 colors and 'light' background
+![grafik](https://i.imgur.com/lg71oqw.png)
 
 # C File
 Displaying [diff.c](https://github.com/vim/vim/blob/3ea62381c527395ae701715335776f427d22eb7b/src/diff.c#L102-L130))
@@ -415,11 +386,11 @@ putty without 'termguicolors' and 256 colors
 ![grafik](https://user-images.githubusercontent.com/244927/227454485-e8cd647b-80fd-47cd-8663-2c5a75a69281.png)
 
 ## [delek](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/delek.vim)
-putty with 'termguicolors'
-![grafik](https://user-images.githubusercontent.com/244927/227453403-a17e8188-9172-4b93-a67d-b34bf5acbb46.png)
+putty with 'termguicolors' and 'light' background
+![grafik](https://i.imgur.com/5JJQNAR.png)
 
-putty without 'termguicolors' and 256 colors
-![grafik](https://user-images.githubusercontent.com/244927/227454521-1f61ff64-44dc-4f51-b590-38dfd51b36b4.png)
+putty without 'termguicolors' and 256 colors and 'light' background
+![grafik](https://i.imgur.com/Lh6sz5g.png)
 
 ## [desert](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/desert.vim)
 putty with 'termguicolors'
@@ -471,11 +442,11 @@ putty without 'termguicolors' and 256 colors
 ![grafik](https://user-images.githubusercontent.com/244927/227454752-7d5eff06-04b8-4cde-aba6-e093c10eeadf.png)
 
 ## [morning](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/morning.vim)
-putty with 'termguicolors'
-![grafik](https://user-images.githubusercontent.com/244927/227453645-5febf877-d458-44ae-aa52-ae79475d10a5.png)
+putty with 'termguicolors' and 'light' background
+![grafik](https://i.imgur.com/zIUISja.png)
 
-putty without 'termguicolors' and 256 colors
-![grafik](https://user-images.githubusercontent.com/244927/227454787-19e0dc20-2b02-45de-a60e-3f71390698ee.png)
+putty without 'termguicolors' and 256 colors and 'light' background
+![grafik](https://i.imgur.com/SgxTO0X.png)
 
 ## [murphy](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/murphy.vim)
 putty with 'termguicolors'
@@ -492,11 +463,11 @@ putty without 'termguicolors' and 256 colors
 ![grafik](https://user-images.githubusercontent.com/244927/227454847-a0ca37f6-83e0-43ac-8e40-fa44ec50b1de.png)
 
 ## [peachpuff](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/peachpuff.vim)
-putty with 'termguicolors'
-![grafik](https://user-images.githubusercontent.com/244927/227453716-923642e2-d671-4350-ac63-a24bc771ed66.png)
+putty with 'termguicolors' and 'light' background
+![grafik](https://i.imgur.com/K8S7gEn.png)
 
-putty without 'termguicolors' and 256 colors
-![grafik](https://user-images.githubusercontent.com/244927/227454876-c711f3aa-f972-4688-96c3-144c634a4bda.png)
+putty without 'termguicolors' and 256 colors and 'light' background
+![grafik](https://i.imgur.com/sRi13jt.png)
 
 ## [quiet](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/quiet.vim)
 putty with 'termguicolors'
@@ -520,11 +491,11 @@ putty without 'termguicolors' and 256 colors
 ![grafik](https://user-images.githubusercontent.com/244927/227454984-bf6be42e-2f36-4517-8801-236a45533aea.png)
 
 ## [shine](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/shine.vim)
-putty with 'termguicolors'
-![grafik](https://user-images.githubusercontent.com/244927/227453822-4bf2c57e-42ad-4862-b332-89e3f3e51572.png)
+putty with 'termguicolors' and 'light' background
+![grafik](https://i.imgur.com/mwIwTef.png)
 
-putty without 'termguicolors' and 256 colors
-![grafik](https://user-images.githubusercontent.com/244927/227455022-3cbf73d7-c7d6-4b5b-b61e-2635b725ebfa.png)
+putty without 'termguicolors' and 256 colors and 'light' background
+![grafik](https://i.imgur.com/9rBka2B.png)
 
 ## [slate](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/slate.vim)
 putty with 'termguicolors'
@@ -562,11 +533,11 @@ putty without 'termguicolors' and 256 colors
 ![grafik](https://user-images.githubusercontent.com/244927/227455166-1c147973-677c-459c-b344-9756514a0248.png)
 
 ## [zellner](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/zellner.vim)
-putty with 'termguicolors'
-![grafik](https://user-images.githubusercontent.com/244927/227454070-176a673e-7e6d-491e-9a84-5af05c920402.png)
+putty with 'termguicolors' and 'light' background
+![grafik](https://i.imgur.com/IICsDNq.png)
 
-putty without 'termguicolors' and 256 colors
-![grafik](https://user-images.githubusercontent.com/244927/227455203-b78ca46b-28ca-4356-b7ca-270f1932a7c4.png)
+putty without 'termguicolors' and 256 colors and 'light' background
+![grafik](https://i.imgur.com/i5r1N9c.png)
 
 # Markdown File
 Displaying [README.md](https://github.com/vim/colorschemes/blob/7a77a9a79a80922a7720048a55ecbd36ebb9a919/README.md)

--- a/ScreenShots.md
+++ b/ScreenShots.md
@@ -2,11 +2,11 @@
 # Let's show some screenshots:
 
 ## Tooling
-All screenshots were made with putty, in a 29x107 size large terminal with a dark backround and termguicolors enabled
-and displaying [check_colors.vim](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/tools/check_colors.vim)
+All screenshots were made with putty, in a 29x107 size large terminal with a dark backround (configured with termguicolors or 256 colors).
 Font: DejaVu Sans Mono for Powerline, 10pt
 
-# Vim File Type
+# Vim9 File
+Displaying [check_colors.vim](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/tools/check_colors.vim)
 
 ## [blue](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/blue.vim)
 putty with 'termguicolors'
@@ -14,7 +14,6 @@ putty with 'termguicolors'
 
 putty without 'termguicolors' and 256 colors
 ![grafik](https://user-images.githubusercontent.com/244927/226842696-62febd29-9eec-4ad9-86e7-eb1c2ba9a0e3.png)
-
 
 ## [darkblue](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/darkblue.vim)
 putty with 'termguicolors'
@@ -177,3 +176,219 @@ putty with 'termguicolors'
 
 putty without 'termguicolors' and 256 colors
 ![grafik](https://user-images.githubusercontent.com/244927/226845083-d2fdb010-4db7-4865-a671-20dd3aa378e1.png)
+
+# Python Files
+Displaying [test_channel.py](https://github.com/vim/vim/blob/890c77203637626b1005db818667084d11e653e7/src/testdir/test_channel.py)
+
+## [blue](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/blue.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/226851051-a1e9a065-65a4-4cbe-9059-506519b10152.png)
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/226848662-4deb7fe9-80c4-4d13-92e1-b0dfcc5e9bf1.png)
+
+## [darkblue](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/darkblue.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/226851082-f7b1b293-f500-4933-b142-4394733c12c5.png)
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/226849849-3b382a2f-b88a-4694-97c3-7f17288d1d0c.png)
+
+## [delek](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/delek.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/226851106-7dc7f3eb-dbf1-4a17-bd21-c107a96fee4e.png)
+
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/226849905-224dc9d9-a3d5-4599-9458-ad42641d364e.png)
+
+
+## [desert](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/desert.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/226851135-4fa10705-6ae8-4f18-98e1-fdf0aa91279d.png)
+
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/226849937-98777391-4781-42b8-8f2a-92ca318334b4.png)
+
+
+## [elflord](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/elflord.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/226851157-e9d26c7e-282c-4bc0-9640-debef569aa04.png)
+
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/226849978-00a4ad6a-3b78-4ef6-8c14-ad5ba30537d1.png)
+
+
+## [evening](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/evening.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/226851183-c6685c26-ece5-461c-85e4-22c0067beea6.png)
+
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/226850126-b9a281db-0ce8-444a-b05b-f3fd6fd23e96.png)
+
+
+## [habamax](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/habamax.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/226851220-c71e27cc-abb3-47a8-9083-99320c4f21f4.png)
+
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/226850158-831003bb-272d-4f51-9c3f-12548cdb1ae2.png)
+
+
+
+## [industry](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/industry.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/226851261-feb4accd-f6f7-4a01-8c12-b086fcb666a5.png)
+
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/226850189-a199f26a-1b3b-449d-b90d-8b573cdc58ab.png)
+
+
+## [koehler](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/koehler.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/226851306-6b9b69a2-c223-4695-9848-00880cec4f49.png)
+
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/226850211-ae06ff79-532c-4887-bea5-cc2c911c30cc.png)
+
+
+## [lunaperch](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/lunaperch.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/226851349-450f9ac8-b063-4346-8fad-f7377fefe2e7.png)
+
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/226850239-715ddac1-3013-48dd-bc4f-6c1fcaea1580.png)
+
+
+## [morning](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/morning.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/226851393-52027639-ea4f-4ee0-93f0-192d1c43f3b9.png)
+
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/226850265-0e6c482a-f75a-4359-8886-7adcf1738f01.png)
+
+
+## [murphy](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/murphy.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/226851420-879d1598-09c8-4cf4-842a-076c6a9ec804.png)
+
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/226850346-26dd4f00-0e9a-41e4-b9c0-0a8a711fba19.png)
+
+
+## [pablo](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/pablo.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/226851456-38b3b874-4336-414f-a302-46acd8e090fb.png)
+
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/226850367-13dc72d8-b782-4e01-a166-2a0cc3d156d2.png)
+
+
+## [peachpuff](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/peachpuff.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/226851491-78ef2f0e-9f80-44c9-8d8e-61f4f4217818.png)
+
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/226850398-3ce6004b-4462-484f-995c-8f4c9369120a.png)
+
+
+## [quiet](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/quiet.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/226851534-2b857a25-94a8-4e6b-bf6a-a783315ead2d.png)
+
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/226850424-a04919ae-74b7-40dd-8988-b49c2dadcad5.png)
+
+
+## [retrobox](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/retrobox.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/226851555-2a8fb08c-8da2-4832-b25b-c493d90379d6.png)
+
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/226850468-4b33621a-0001-4b59-84ea-061333f24c98.png)
+
+
+## [ron](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/ron.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/226851598-b245c3c3-ce57-482e-8d47-3df84d6dc63d.png)
+
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/226850507-a1600b7c-2f4d-48fe-b577-607ae4411c34.png)
+
+
+## [shine](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/shine.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/226851622-545ccf29-06a1-41ff-a318-f04b3cf3ed6e.png)
+
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/226850569-9011750b-bf17-4605-9d09-7e3f2c947b0f.png)
+
+
+## [slate](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/slate.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/226851658-e2ed398b-6373-4451-b22a-eadbfbce927c.png)
+
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/226850612-66d1af4c-dd52-4111-a70a-cc9111f0ab40.png)
+
+
+## [sorbet](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/sorbet.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/226851680-10f78c80-edc2-403c-acc3-603546929a9e.png)
+
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/226850661-ac4345d4-0b63-424c-b2dc-9e9cc4b3420c.png)
+
+
+## [torte](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/torte.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/226851715-3916ee4c-587e-4adf-9b5e-ffe9a79c4c2b.png)
+
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/226850712-4020ce24-97c4-453e-b0a7-e7c090310b06.png)
+
+
+## [wildcharm](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/wildcharm.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/226851747-fa7e4815-7a1d-4ce8-8139-3f227776c12b.png)
+
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/226850760-52bf8537-bcfe-44a5-a61a-c363fcdf11eb.png)
+
+
+## [zaibatsu](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/zaibatsu.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/226851769-20c27625-11a4-4dd8-ba6e-690e1d0b199e.png)
+
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/226850800-7b854bce-995f-4e5e-a961-0ecbb6a30867.png)
+
+
+## [zellner](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/zellner.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/226851809-bc94c0a6-de63-4519-af09-3cd3589e3fb8.png)
+
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/226850837-4da6c7c5-133a-4810-9f6b-396321b5e069.png)
+

--- a/ScreenShots.md
+++ b/ScreenShots.md
@@ -2,3 +2,6 @@
 # Let's show some screenshots:
 
 All screenshots were made with putty, a dark backround and termguicolors enabled.
+
+## [blue](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/blue.vim)
+![grafik](https://user-images.githubusercontent.com/244927/226671314-8e09c1c0-3860-40b2-9bf4-5c16112e0581.png)

--- a/ScreenShots.md
+++ b/ScreenShots.md
@@ -6,75 +6,174 @@ All screenshots were made with putty, in a 29x107 size large terminal with a dar
 and displaying [check_colors.vim](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/tools/check_colors.vim)
 Font: DejaVu Sans Mono for Powerline, 10pt
 
+# Vim File Type
 
 ## [blue](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/blue.vim)
+putty with 'termguicolors'
 ![grafik](https://user-images.githubusercontent.com/244927/226674769-6d69a424-a87a-44b6-965e-9c9584b4e1d7.png)
 
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/226842696-62febd29-9eec-4ad9-86e7-eb1c2ba9a0e3.png)
+
+
 ## [darkblue](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/darkblue.vim)
+putty with 'termguicolors'
 ![grafik](https://user-images.githubusercontent.com/244927/226674886-ee590186-ac57-41fd-a42f-ad2823a705e3.png)
 
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/226843553-a27c203f-3c17-42a8-909f-4859e01417d5.png)
+
 ## [delek](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/delek.vim)
+putty with 'termguicolors'
 ![grafik](https://user-images.githubusercontent.com/244927/226674977-319167f3-5ce7-4a46-a625-95f6e30215e4.png)
 
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/226843607-b6ad101d-f96c-4256-82ae-e4fbe7fe1bd0.png)
+
 ## [desert](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/desert.vim)
+putty with 'termguicolors'
 ![grafik](https://user-images.githubusercontent.com/244927/226675186-b4d1bb19-afdd-471a-97e0-8797c2a085f9.png)
 
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/226843661-33afe7e8-2d9b-4262-bd1a-3e9d7a4b524d.png)
+
 ## [elflord](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/elflord.vim)
+putty with 'termguicolors'
 ![grafik](https://user-images.githubusercontent.com/244927/226675509-bf88ab9b-26e1-41ad-969b-0e8203408afb.png)
 
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/226843727-2a36bad6-6e21-4691-9e88-aa563719c87c.png)
+
 ## [evening](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/evening.vim)
+putty with 'termguicolors'
 ![grafik](https://user-images.githubusercontent.com/244927/226675647-9ee5133d-70dc-449a-997e-ac29ea196d03.png)
 
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/226843778-b271e77c-6f95-4eaf-be67-da9cc1ca17da.png)
+
 ## [habamax](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/habamax.vim)
+putty with 'termguicolors'
 ![grafik](https://user-images.githubusercontent.com/244927/226675967-935b4737-7578-412b-b766-18cd223b5f8f.png)
 
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/226843826-7f9452fa-0745-4ae6-8c9f-51b5517da5d8.png)
+
+
 ## [industry](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/industry.vim)
+putty with 'termguicolors'
 ![grafik](https://user-images.githubusercontent.com/244927/226676104-7598a515-4738-44be-8e85-dd9799980ad6.png)
 
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/226843879-a36c5e6f-8685-400f-9182-454d4dbfe6dd.png)
+
 ## [koehler](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/koehler.vim)
+putty with 'termguicolors'
 ![grafik](https://user-images.githubusercontent.com/244927/226676243-2511c865-410b-420a-a21f-08f5274beff0.png)
 
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/226843935-52ff27a9-4065-482e-9cc2-9bdc6342e461.png)
+
 ## [lunaperch](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/lunaperch.vim)
+putty with 'termguicolors'
 ![grafik](https://user-images.githubusercontent.com/244927/226676420-b889d005-f7ad-48f7-aa84-5f90b7920fcb.png)
 
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/226843971-82f34c20-4ce0-44d8-8b5f-c457c3e371e5.png)
+
 ## [morning](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/morning.vim)
+putty with 'termguicolors'
 ![grafik](https://user-images.githubusercontent.com/244927/226676609-8c3a5ef8-c2f7-4bcc-8f2e-8dc41d9c54a5.png)
 
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/226844020-afa7ab35-ab0e-4be5-a2e4-ef2dbe65fc16.png)
+
 ## [murphy](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/murphy.vim)
+putty with 'termguicolors'
 ![grafik](https://user-images.githubusercontent.com/244927/226676750-af7db29b-3d5b-4d0f-a3dd-ac4b2cc38235.png)
 
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/226844059-642728a7-f688-4e3d-b0d4-34552dae6af8.png)
+
 ## [pablo](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/pablo.vim)
+putty with 'termguicolors'
 ![grafik](https://user-images.githubusercontent.com/244927/226676918-503c1455-7877-404c-97e1-f656fd095d27.png)
 
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/226844117-fbaae4ca-afdb-4104-aacf-a5d3ca88a230.png)
+
 ## [peachpuff](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/peachpuff.vim)
+putty with 'termguicolors'
 ![grafik](https://user-images.githubusercontent.com/244927/226677023-be845a95-d627-495c-92f1-d37c08e34387.png)
 
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/226844161-aaf3b43b-664d-444c-996d-916ccc3564cc.png)
+
 ## [quiet](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/quiet.vim)
+putty with 'termguicolors'
 ![grafik](https://user-images.githubusercontent.com/244927/226677247-c2adef84-8d3a-49cf-898e-35b2cecb787d.png)
 
+putty without 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/226844239-35d18954-fcaf-453b-8f44-4a19e20ac305.png)
+
 ## [retrobox](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/retrobox.vim)
+putty with 'termguicolors'
 ![grafik](https://user-images.githubusercontent.com/244927/226677397-02196d0c-4297-472f-98c4-4d9d2ac3fafb.png)
 
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/226844296-8e91a260-b7ca-4f40-91ff-c621d9e54c6f.png)
+
 ## [ron](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/ron.vim)
+putty with 'termguicolors'
 ![grafik](https://user-images.githubusercontent.com/244927/226677520-62509ecf-dfd9-40eb-bb8c-593f842a9f32.png)
 
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/226844368-5bccade8-8b04-4e20-9ca3-b7ce5ce31b1a.png)
+
 ## [shine](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/shine.vim)
+putty with 'termguicolors'
 ![grafik](https://user-images.githubusercontent.com/244927/226677637-422a4da1-a976-42a7-8c5d-d449c96d6607.png)
 
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/226844451-e0b808b3-3291-4dd6-9978-652f571875fe.png)
+
 ## [slate](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/slate.vim)
+putty with 'termguicolors'
 ![grafik](https://user-images.githubusercontent.com/244927/226677764-483652b9-5bc5-4832-9b75-028135f1bf10.png)
 
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/226844552-2363dcc9-639e-4916-a339-497b87032899.png)
+
 ## [sorbet](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/sorbet.vim)
+putty with 'termguicolors'
 ![grafik](https://user-images.githubusercontent.com/244927/226677896-5dab2a0a-ceb2-4e3b-88df-1e7f922a0e74.png)
 
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/226844644-ae8ade37-6d4a-4801-a4e1-f3a6594e3ebe.png)
+
 ## [torte](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/torte.vim)
+putty with 'termguicolors'
 ![grafik](https://user-images.githubusercontent.com/244927/226677994-d07cb4a3-2436-4909-a7cb-dcbaf71e535a.png)
 
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/226844809-e293829e-0881-4d0d-9d20-699ffa882dba.png)
+
 ## [wildcharm](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/wildcharm.vim)
+putty with 'termguicolors'
 ![grafik](https://user-images.githubusercontent.com/244927/226678080-40adf59e-1b9b-48bc-aac2-3551e6fb69ba.png)
 
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/226844911-f21f1bb6-751f-4ea0-ad45-5654ef200cff.png)
+
 ## [zaibatsu](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/zaibatsu.vim)
+putty with 'termguicolors'
 ![grafik](https://user-images.githubusercontent.com/244927/226678222-4efc274f-b774-4783-a69b-085588d3c3e1.png)
 
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/226844986-d181ebff-4375-4d5f-bd7e-a6f04ecfa744.png)
+
 ## [zellner](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/zellner.vim)
+putty with 'termguicolors'
 ![grafik](https://user-images.githubusercontent.com/244927/226678374-28318b04-9e5c-41a9-a6ec-d453a40e1a93.png)
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/226845083-d2fdb010-4db7-4865-a671-20dd3aa378e1.png)

--- a/ScreenShots.md
+++ b/ScreenShots.md
@@ -1,0 +1,4 @@
+
+# Let's show some screenshots:
+
+All screenshots were made with putty, a dark backround and termguicolors enabled.

--- a/ScreenShots.md
+++ b/ScreenShots.md
@@ -1,7 +1,80 @@
 
 # Let's show some screenshots:
 
-All screenshots were made with putty, a dark backround and termguicolors enabled.
+## Tooling
+All screenshots were made with putty, in a 29x107 size large terminal with a dark backround and termguicolors enabled
+and displaying [check_colors.vim](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/tools/check_colors.vim)
+Font: DejaVu Sans Mono for Powerline, 10pt
+
 
 ## [blue](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/blue.vim)
-![grafik](https://user-images.githubusercontent.com/244927/226671314-8e09c1c0-3860-40b2-9bf4-5c16112e0581.png)
+![grafik](https://user-images.githubusercontent.com/244927/226674769-6d69a424-a87a-44b6-965e-9c9584b4e1d7.png)
+
+## [darkblue](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/darkblue.vim)
+![grafik](https://user-images.githubusercontent.com/244927/226674886-ee590186-ac57-41fd-a42f-ad2823a705e3.png)
+
+## [delek](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/delek.vim)
+![grafik](https://user-images.githubusercontent.com/244927/226674977-319167f3-5ce7-4a46-a625-95f6e30215e4.png)
+
+## [desert](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/desert.vim)
+![grafik](https://user-images.githubusercontent.com/244927/226675186-b4d1bb19-afdd-471a-97e0-8797c2a085f9.png)
+
+## [elflord](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/elflord.vim)
+![grafik](https://user-images.githubusercontent.com/244927/226675509-bf88ab9b-26e1-41ad-969b-0e8203408afb.png)
+
+## [evening](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/evening.vim)
+![grafik](https://user-images.githubusercontent.com/244927/226675647-9ee5133d-70dc-449a-997e-ac29ea196d03.png)
+
+## [habamax](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/habamax.vim)
+![grafik](https://user-images.githubusercontent.com/244927/226675967-935b4737-7578-412b-b766-18cd223b5f8f.png)
+
+## [industry](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/industry.vim)
+![grafik](https://user-images.githubusercontent.com/244927/226676104-7598a515-4738-44be-8e85-dd9799980ad6.png)
+
+## [koehler](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/koehler.vim)
+![grafik](https://user-images.githubusercontent.com/244927/226676243-2511c865-410b-420a-a21f-08f5274beff0.png)
+
+## [lunaperch](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/lunaperch.vim)
+![grafik](https://user-images.githubusercontent.com/244927/226676420-b889d005-f7ad-48f7-aa84-5f90b7920fcb.png)
+
+## [morning](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/morning.vim)
+![grafik](https://user-images.githubusercontent.com/244927/226676609-8c3a5ef8-c2f7-4bcc-8f2e-8dc41d9c54a5.png)
+
+## [murphy](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/murphy.vim)
+![grafik](https://user-images.githubusercontent.com/244927/226676750-af7db29b-3d5b-4d0f-a3dd-ac4b2cc38235.png)
+
+## [pablo](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/pablo.vim)
+![grafik](https://user-images.githubusercontent.com/244927/226676918-503c1455-7877-404c-97e1-f656fd095d27.png)
+
+## [peachpuff](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/peachpuff.vim)
+![grafik](https://user-images.githubusercontent.com/244927/226677023-be845a95-d627-495c-92f1-d37c08e34387.png)
+
+## [quiet](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/quiet.vim)
+![grafik](https://user-images.githubusercontent.com/244927/226677247-c2adef84-8d3a-49cf-898e-35b2cecb787d.png)
+
+## [retrobox](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/retrobox.vim)
+![grafik](https://user-images.githubusercontent.com/244927/226677397-02196d0c-4297-472f-98c4-4d9d2ac3fafb.png)
+
+## [ron](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/ron.vim)
+![grafik](https://user-images.githubusercontent.com/244927/226677520-62509ecf-dfd9-40eb-bb8c-593f842a9f32.png)
+
+## [shine](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/shine.vim)
+![grafik](https://user-images.githubusercontent.com/244927/226677637-422a4da1-a976-42a7-8c5d-d449c96d6607.png)
+
+## [slate](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/slate.vim)
+![grafik](https://user-images.githubusercontent.com/244927/226677764-483652b9-5bc5-4832-9b75-028135f1bf10.png)
+
+## [sorbet](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/sorbet.vim)
+![grafik](https://user-images.githubusercontent.com/244927/226677896-5dab2a0a-ceb2-4e3b-88df-1e7f922a0e74.png)
+
+## [torte](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/torte.vim)
+![grafik](https://user-images.githubusercontent.com/244927/226677994-d07cb4a3-2436-4909-a7cb-dcbaf71e535a.png)
+
+## [wildcharm](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/wildcharm.vim)
+![grafik](https://user-images.githubusercontent.com/244927/226678080-40adf59e-1b9b-48bc-aac2-3551e6fb69ba.png)
+
+## [zaibatsu](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/zaibatsu.vim)
+![grafik](https://user-images.githubusercontent.com/244927/226678222-4efc274f-b774-4783-a69b-085588d3c3e1.png)
+
+## [zellner](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/zellner.vim)
+![grafik](https://user-images.githubusercontent.com/244927/226678374-28318b04-9e5c-41a9-a6ec-d453a40e1a93.png)

--- a/ScreenShots.md
+++ b/ScreenShots.md
@@ -428,14 +428,12 @@ putty with 'termguicolors'
 putty without 'termguicolors' and 256 colors
 ![grafik](https://user-images.githubusercontent.com/244927/227454558-6ce1c21b-1c2a-453c-b7a5-35f7ec87c8f2.png)
 
-
 ## [elflord](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/elflord.vim)
 putty with 'termguicolors'
 ![grafik](https://user-images.githubusercontent.com/244927/227453469-7fc73382-5d87-4926-8ce8-08be50bfd685.png)
 
 putty without 'termguicolors' and 256 colors
 ![grafik](https://user-images.githubusercontent.com/244927/227454596-97616756-064a-4bd8-84c2-f56d24a0eac2.png)
-
 
 ## [evening](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/evening.vim)
 putty with 'termguicolors'
@@ -458,7 +456,6 @@ putty with 'termguicolors'
 putty without 'termguicolors' and 256 colors
 ![grafik](https://user-images.githubusercontent.com/244927/227454693-342737ed-6b3d-49ee-a394-c7f2689d4abb.png)
 
-
 ## [koehler](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/koehler.vim)
 putty with 'termguicolors'
 ![grafik](https://user-images.githubusercontent.com/244927/227453590-a682174f-2d49-41c6-9039-66e411b0f279.png)
@@ -472,7 +469,6 @@ putty with 'termguicolors'
 
 putty without 'termguicolors' and 256 colors
 ![grafik](https://user-images.githubusercontent.com/244927/227454752-7d5eff06-04b8-4cde-aba6-e093c10eeadf.png)
-
 
 ## [morning](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/morning.vim)
 putty with 'termguicolors'
@@ -591,10 +587,10 @@ putty without 'termguicolors' and 256 colors
 
 ## [delek](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/delek.vim)
 putty with 'termguicolors' and 'light' background
-![grafik](https://user-images.githubusercontent.com/244927/227461283-563684ae-cf56-4c24-bbaa-44f4343a3971.png)
+![grafik](https://i.imgur.com/uPiJLGk.png)
 
-putty without 'termguicolors' and 256 colors
-![grafik](https://user-images.githubusercontent.com/244927/227457979-721d11b6-d0e9-4e59-b652-41ca1bc40b92.png)
+putty without 'termguicolors' and 256 colors and 'light' background
+![grafik](https://i.imgur.com/8C4nBiC.png)
 
 ## [desert](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/desert.vim)
 putty with 'termguicolors'
@@ -647,9 +643,10 @@ putty without 'termguicolors' and 256 colors
 
 ## [morning](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/morning.vim)
 putty with 'termguicolors' and 'light' background
+![grafik](https://i.imgur.com/snIvJkZ.png)
 
 putty without 'termguicolors' and 256 colors and 'light' background
-
+![grafik](https://i.imgur.com/ZbmQz5i.png)
 
 ## [murphy](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/murphy.vim)
 putty with 'termguicolors'
@@ -667,8 +664,10 @@ putty without 'termguicolors' and 256 colors
 
 ## [peachpuff](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/peachpuff.vim)
 putty with 'termguicolors' and 'light' background
+![grafik](https://i.imgur.com/PYfrNej.png)
 
 putty without 'termguicolors' and 256 colors and 'light' background
+![grafik](https://i.imgur.com/QELw3yo.png)
 
 ## [quiet](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/quiet.vim)
 putty with 'termguicolors'
@@ -693,9 +692,10 @@ putty without 'termguicolors' and 256 colors
 
 ## [shine](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/shine.vim)
 putty with 'termguicolors' and 'light' background
-![grafik](https://user-images.githubusercontent.com/244927/227457405-be5d55ad-d9eb-442c-8876-6273fd997209.png)
+![grafik](https://i.imgur.com/WNunaVJ.png)
 
 putty without 'termguicolors' and 256 colors and 'light' background
+![grafik](https://i.imgur.com/blIGLHG.png)
 
 ## [slate](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/slate.vim)
 putty with 'termguicolors'
@@ -734,5 +734,7 @@ putty without 'termguicolors' and 256 colors
 
 ## [zellner](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/zellner.vim)
 putty with 'termguicolors' and 'light' background
+![grafik](https://i.imgur.com/SAIdZ7M.png)
 
 putty without 'termguicolors' and 256 colors and 'light' background
+![grafik](https://i.imgur.com/ExtF8MY.png)

--- a/ScreenShots.md
+++ b/ScreenShots.md
@@ -8,7 +8,7 @@
 
 ## Tooling
 All screenshots were made with putty, in a 29x107 size large terminal with a dark backround (configured with termguicolors or 256 colors).
-Font: DejaVu Sans Mono for Powerline, 10pt
+Font: DejaVu Sans Mono for Powerline, 12pt
 
 # Vim9 File
 Displaying [check_colors.vim](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/tools/check_colors.vim)

--- a/ScreenShots.md
+++ b/ScreenShots.md
@@ -590,12 +590,11 @@ putty without 'termguicolors' and 256 colors
 ![grafik](https://user-images.githubusercontent.com/244927/227457949-7e04e9cf-cb32-4a61-a191-f65aa5031c18.png)
 
 ## [delek](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/delek.vim)
-putty with 'termguicolors'
-![grafik](https://user-images.githubusercontent.com/244927/227456732-46bee636-1f5b-4b0e-9ce3-1e41ecf1e5ea.png)
+putty with 'termguicolors' and 'light' background
+![grafik](https://user-images.githubusercontent.com/244927/227461283-563684ae-cf56-4c24-bbaa-44f4343a3971.png)
 
 putty without 'termguicolors' and 256 colors
 ![grafik](https://user-images.githubusercontent.com/244927/227457979-721d11b6-d0e9-4e59-b652-41ca1bc40b92.png)
-
 
 ## [desert](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/desert.vim)
 putty with 'termguicolors'
@@ -647,11 +646,10 @@ putty without 'termguicolors' and 256 colors
 ![grafik](https://user-images.githubusercontent.com/244927/227458220-024e2f51-a345-4c61-8051-6ab9000a765d.png)
 
 ## [morning](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/morning.vim)
-putty with 'termguicolors'
-![grafik](https://user-images.githubusercontent.com/244927/227457110-9ba4afa7-3ea8-4630-97c0-953864b90ebf.png)
+putty with 'termguicolors' and 'light' background
 
-putty without 'termguicolors' and 256 colors
-![grafik](https://user-images.githubusercontent.com/244927/227458258-df44bbaa-6c8d-4e92-a822-1d50260cf0c2.png)
+putty without 'termguicolors' and 256 colors and 'light' background
+
 
 ## [murphy](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/murphy.vim)
 putty with 'termguicolors'
@@ -668,11 +666,9 @@ putty without 'termguicolors' and 256 colors
 ![grafik](https://user-images.githubusercontent.com/244927/227458327-3addc2c6-8f09-420b-bc4f-0e830201a70d.png)
 
 ## [peachpuff](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/peachpuff.vim)
-putty with 'termguicolors'
-![grafik](https://user-images.githubusercontent.com/244927/227457212-6305dde7-f036-46f6-81a2-c68426564a37.png)
+putty with 'termguicolors' and 'light' background
 
-putty without 'termguicolors' and 256 colors
-![grafik](https://user-images.githubusercontent.com/244927/227458363-31a4a1b2-6149-433e-b452-64229de0e1ea.png)
+putty without 'termguicolors' and 256 colors and 'light' background
 
 ## [quiet](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/quiet.vim)
 putty with 'termguicolors'
@@ -696,11 +692,10 @@ putty without 'termguicolors' and 256 colors
 ![grafik](https://user-images.githubusercontent.com/244927/227458448-c039dd62-fa46-4a20-acbf-f5a9cfcb2e59.png)
 
 ## [shine](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/shine.vim)
-putty with 'termguicolors'
+putty with 'termguicolors' and 'light' background
 ![grafik](https://user-images.githubusercontent.com/244927/227457405-be5d55ad-d9eb-442c-8876-6273fd997209.png)
 
-putty without 'termguicolors' and 256 colors
-![grafik](https://user-images.githubusercontent.com/244927/227458474-fd382c79-94ec-40ae-8e17-6f53ff4874ab.png)
+putty without 'termguicolors' and 256 colors and 'light' background
 
 ## [slate](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/slate.vim)
 putty with 'termguicolors'
@@ -738,8 +733,6 @@ putty without 'termguicolors' and 256 colors
 ![grafik](https://user-images.githubusercontent.com/244927/227458588-3a1a58fb-a7a9-4d3e-abbf-f66964c3fa3a.png)
 
 ## [zellner](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/zellner.vim)
-putty with 'termguicolors'
-![grafik](https://user-images.githubusercontent.com/244927/227457663-f8e0bbdb-8a35-45d4-aa4a-ec3215f895cd.png)
+putty with 'termguicolors' and 'light' background
 
-putty without 'termguicolors' and 256 colors
-![grafik](https://user-images.githubusercontent.com/244927/227458611-0523fdf7-6abb-4557-85ab-e8cc27c57454.png)
+putty without 'termguicolors' and 256 colors and 'light' background

--- a/ScreenShots.md
+++ b/ScreenShots.md
@@ -4,6 +4,7 @@
 - [Vim9 File](#vim9-file)
 - [Python File](#python-file)
 - [C File](#c-file)
+- [Markdown File](#markdown-file)
 
 ## Tooling
 All screenshots were made with putty, in a 29x107 size large terminal with a dark backround (configured with termguicolors or 256 colors).
@@ -396,7 +397,6 @@ putty with 'termguicolors'
 putty without 'termguicolors' and 256 colors
 ![grafik](https://user-images.githubusercontent.com/244927/226850837-4da6c7c5-133a-4810-9f6b-396321b5e069.png)
 
-
 # C File
 Displaying [diff.c](https://github.com/vim/vim/blob/3ea62381c527395ae701715335776f427d22eb7b/src/diff.c#L102-L130))
 
@@ -571,3 +571,175 @@ putty with 'termguicolors'
 
 putty without 'termguicolors' and 256 colors
 ![grafik](https://user-images.githubusercontent.com/244927/227455203-b78ca46b-28ca-4356-b7ca-270f1932a7c4.png)
+
+# Markdown File
+Displaying [README.md](https://github.com/vim/colorschemes/blob/7a77a9a79a80922a7720048a55ecbd36ebb9a919/README.md)
+
+## [blue](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/blue.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/227456666-e9f8c50c-d7cf-4d0a-867c-6ec55e3d03a9.png)
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/227457921-95cf4f6a-b517-496b-acf6-42823809c9a4.png)
+
+## [darkblue](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/darkblue.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/227456453-e3e6f293-b63e-4295-b840-32fa939a9f9a.png)
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/227457949-7e04e9cf-cb32-4a61-a191-f65aa5031c18.png)
+
+## [delek](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/delek.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/227456732-46bee636-1f5b-4b0e-9ce3-1e41ecf1e5ea.png)
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/227457979-721d11b6-d0e9-4e59-b652-41ca1bc40b92.png)
+
+
+## [desert](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/desert.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/227456778-d4a08721-3bd0-492e-ba6b-3afff1a399dd.png)
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/227458005-b5a295e6-dff6-48a3-a3d5-3c243a244d7e.png)
+
+## [elflord](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/elflord.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/227456803-0f79179c-ed47-49a5-9ff1-1802f3953ccd.png)
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/227458055-cada45fb-f13b-49c6-8b2b-555829b842f2.png)
+
+## [evening](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/evening.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/227456875-6e8c3102-6e5c-4eb5-85ea-bbe3682434c6.png)
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/227458076-4f9ceb7f-8fa4-4b02-a59f-19e729ba5eca.png)
+
+## [habamax](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/habamax.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/227456930-c78ff6f6-ccd7-4b46-b8c0-3d344f85b3bc.png)
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/227458095-83f2a4da-ff27-464b-b5d5-6b8ec6a69ff9.png)
+
+## [industry](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/industry.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/227456970-45136dfd-fef1-4f15-bbf8-a3880ab0cae8.png)
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/227458123-6f98d5bf-0233-4b72-b517-d33cbe180c67.png)
+
+## [koehler](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/koehler.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/227456985-42e92835-96d7-4351-ba7d-44d579c27265.png)
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/227458164-f5ba20fc-0f2d-4d57-8dcc-ee55a99c4505.png)
+
+## [lunaperch](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/lunaperch.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/227457044-09713b71-56c9-47a8-a302-dcc5a3798fef.png)
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/227458220-024e2f51-a345-4c61-8051-6ab9000a765d.png)
+
+## [morning](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/morning.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/227457110-9ba4afa7-3ea8-4630-97c0-953864b90ebf.png)
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/227458258-df44bbaa-6c8d-4e92-a822-1d50260cf0c2.png)
+
+## [murphy](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/murphy.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/227457147-50ac9c07-18d9-4a07-9f0a-f006f26d5f47.png)
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/227458295-6cb2346c-c538-4612-86e1-915d4a7ee7de.png)
+
+## [pablo](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/pablo.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/227457178-3ef5fb2c-719e-4f60-a3b1-c0a84b74682c.png)
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/227458327-3addc2c6-8f09-420b-bc4f-0e830201a70d.png)
+
+## [peachpuff](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/peachpuff.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/227457212-6305dde7-f036-46f6-81a2-c68426564a37.png)
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/227458363-31a4a1b2-6149-433e-b452-64229de0e1ea.png)
+
+## [quiet](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/quiet.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/227457250-3e75578b-216f-4eb7-a698-a206d6639836.png)
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/227458380-3aa43035-4df5-48f9-9ee9-62dca64f5e60.png)
+
+## [retrobox](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/retrobox.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/227457340-bcf304db-029f-4a04-9036-57ec0aff9544.png)
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/227458413-4ff066d9-c1b2-4bb6-9a41-2d376fb82eca.png)
+
+## [ron](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/ron.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/227457376-e06e470c-9cf1-477a-8c71-83b8686321fb.png)
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/227458448-c039dd62-fa46-4a20-acbf-f5a9cfcb2e59.png)
+
+## [shine](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/shine.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/227457405-be5d55ad-d9eb-442c-8876-6273fd997209.png)
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/227458474-fd382c79-94ec-40ae-8e17-6f53ff4874ab.png)
+
+## [slate](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/slate.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/227457452-8163f194-bdf3-4ba1-a516-995b91d50f22.png)
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/227458492-f54942ee-3b76-4aa4-8922-3b2696d23a26.png)
+
+## [sorbet](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/sorbet.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/227457484-80201f2d-9ac2-41a6-ae91-3cf81b3fc67e.png)
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/227458514-f883068d-070d-400c-9947-d996e27f268f.png)
+
+## [torte](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/torte.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/227457533-acb97fd9-70fa-4a35-971f-ad50e75b6314.png)
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/227458536-3a66fe58-1a16-4a16-8ebc-a9d91b8d4793.png)
+
+## [wildcharm](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/wildcharm.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/227457586-6347b17b-8793-4b51-9ad4-94cafc4bb40e.png)
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/227458559-d9f130cb-7f69-47de-8dd2-7f3c6d065474.png)
+
+## [zaibatsu](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/zaibatsu.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/227457625-b6f26cac-0549-47bf-91c4-402870880025.png)
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/227458588-3a1a58fb-a7a9-4d3e-abbf-f66964c3fa3a.png)
+
+## [zellner](https://github.com/vim/colorschemes/blob/c8f5b1f0429313439d3bc0762cdddb3aa6aaf4f3/colors/zellner.vim)
+putty with 'termguicolors'
+![grafik](https://user-images.githubusercontent.com/244927/227457663-f8e0bbdb-8a35-45d4-aa4a-ec3215f895cd.png)
+
+putty without 'termguicolors' and 256 colors
+![grafik](https://user-images.githubusercontent.com/244927/227458611-0523fdf7-6abb-4557-85ab-e8cc27c57454.png)


### PR DESCRIPTION
Hi,
I thought, it may make sense to add some screenshots so that users can easily see how each colorscheme will look like. 

It might also show some deficiencies, e.g. I noticed the visual highlighting for the habamax colorscheme with 'termguicolors' is quite bad cc @habamax fyi.

Anyhow, I tried to include different filetypes with different settings (with termguicolors and without termguicolors (in which case I used 256colors)) and the proper background setting dark except for `delek, morning, peachpuff, shine and zellner` which seem to use a light background. I tried to make this as reproducible as possible, by always mentioning with which revision a colorscheme and the target filetype has been snapshoted. 

Also while at it, I generate a small toc for the main Readme and added a link to the new ScreenShot.md.