### PR TITLE
check_colors: tweak check for t_Co and add missing highlight groups.

### DIFF
--- a/colors/tools/check_colors.vim
+++ b/colors/tools/check_colors.vim
@@ -34,7 +34,7 @@ def Test_check_colors()
         'Comment',
         'Conceal',
         'Constant',
-	'CurSearch',
+        'CurSearch',
         'Cursor',
         'CursorColumn',
         'CursorLine',
@@ -66,6 +66,8 @@ def Test_check_colors()
         'PmenuSbar',
         'PmenuSel',
         'PmenuThumb',
+        'PopupNotification',
+        'PopupSelected',
         'PreProc',
         'Question',
         'QuickFixLine',
@@ -156,7 +158,7 @@ def Test_check_colors()
     cursor(1, 1)
 
     # 4) Check, that t_Co is checked
-    var pat = '[&]t_Co\s*\%(\%([<>=]=\?\)\|??\)\s*\d\+'
+    var pat = '[&]t_Co)\?\s*\%(\%([<>=]=\?\)\|??\)\s*\d\+'
     if search(pat, 'ncW') == 0
         err['t_Co'] = 'Does not check terminal for capable colors'
     endif


### PR DESCRIPTION
In Vim 9 script, `&t_Co` cannot be directly compared with a number because it has type `string`. You must do, e.g., `str2nr(&t_Co) > 256`. The parentheses prevent `check_colors.vim` to detect the comparison. This PR fixes that.

This PR also adds a couple of missing highlight groups.