### PR TITLE
differentiate tabline and cursorline in novum

### DIFF
--- a/colors/novum.vim
+++ b/colors/novum.vim
@@ -70,7 +70,7 @@ if &background == 'dark'
   hi CurSearch guifg=#07080d guibg=#fce094 guisp=NONE gui=NONE ctermfg=232 ctermbg=222 cterm=NONE term=reverse
   hi Cursor guifg=bg guibg=fg guisp=NONE gui=NONE ctermfg=bg ctermbg=fg cterm=NONE term=reverse
   hi CursorColumn guifg=NONE guibg=#2c2e33 guisp=NONE gui=NONE ctermfg=NONE ctermbg=236 cterm=NONE term=NONE
-  hi CursorLine guifg=NONE guibg=#2c2e33 guisp=NONE gui=NONE ctermfg=NONE ctermbg=236 cterm=NONE term=underline
+  hi CursorLine guifg=NONE guibg=#384851 guisp=NONE gui=NONE ctermfg=NONE ctermbg=239 cterm=NONE term=underline
   hi CursorLineNr guifg=NONE guibg=NONE guisp=NONE gui=bold ctermfg=NONE ctermbg=NONE cterm=bold term=bold
   hi Delimiter guifg=#e0e2ea guibg=NONE guisp=NONE gui=NONE ctermfg=188 ctermbg=NONE cterm=NONE term=NONE
   hi DiffAdd guifg=#eef1f8 guibg=#005523 guisp=NONE gui=NONE ctermfg=231 ctermbg=22 cterm=NONE term=reverse
@@ -142,7 +142,7 @@ if &background == 'dark'
     hi CurSearch ctermfg=Black ctermbg=Yellow cterm=bold,reverse
     hi Cursor ctermfg=bg ctermbg=fg cterm=NONE
     hi CursorColumn ctermfg=NONE ctermbg=DarkGray cterm=NONE
-    hi CursorLine ctermfg=NONE ctermbg=DarkGray cterm=underline
+    hi CursorLine ctermfg=NONE ctermbg=LightBlue cterm=underline
     hi CursorLineNr ctermfg=Yellow ctermbg=NONE cterm=NONE
     hi Delimiter ctermfg=LightGray ctermbg=NONE cterm=NONE
     hi DiffAdd ctermfg=White ctermbg=DarkGreen cterm=NONE
@@ -310,7 +310,7 @@ if &background == 'light'
   hi CurSearch guifg=#eef1f8 guibg=#6b5300 guisp=NONE gui=NONE ctermfg=231 ctermbg=58 cterm=NONE term=reverse
   hi Cursor guifg=bg guibg=fg guisp=NONE gui=NONE ctermfg=bg ctermbg=fg cterm=NONE term=reverse
   hi CursorColumn guifg=NONE guibg=#c4c6cd guisp=NONE gui=NONE ctermfg=NONE ctermbg=251 cterm=NONE term=NONE
-  hi CursorLine guifg=NONE guibg=#c4c6cd guisp=NONE gui=NONE ctermfg=NONE ctermbg=251 cterm=NONE term=underline
+  hi CursorLine guifg=NONE guibg=#b8cfc7 guisp=NONE gui=NONE ctermfg=NONE ctermbg=152 cterm=NONE term=underline
   hi CursorLineNr guifg=NONE guibg=NONE guisp=NONE gui=bold ctermfg=NONE ctermbg=NONE cterm=bold term=bold
   hi Delimiter guifg=#14161b guibg=NONE guisp=NONE gui=NONE ctermfg=233 ctermbg=NONE cterm=NONE term=NONE
   hi DiffAdd guifg=#07080d guibg=#b3f6c0 guisp=NONE gui=NONE ctermfg=232 ctermbg=157 cterm=NONE term=reverse
@@ -382,7 +382,7 @@ if &background == 'light'
     hi CurSearch ctermfg=White ctermbg=Brown cterm=bold,reverse
     hi Cursor ctermfg=bg ctermbg=fg cterm=NONE
     hi CursorColumn ctermfg=NONE ctermbg=LightGray cterm=NONE
-    hi CursorLine ctermfg=NONE ctermbg=LightGray cterm=underline
+    hi CursorLine ctermfg=NONE ctermbg=LightGreen cterm=underline
     hi CursorLineNr ctermfg=Brown ctermbg=NONE cterm=NONE
     hi Delimiter ctermfg=Black ctermbg=NONE cterm=NONE
     hi DiffAdd ctermfg=Black ctermbg=LightGreen cterm=NONE

--- a/colortemplate/novum.colortemplate
+++ b/colortemplate/novum.colortemplate
@@ -72,8 +72,8 @@ CurSearch                              longDhole  poorLlama
 /16                                    longDhole  poorLlama   bold,reverse
 Cursor                                 bg         fg
 CursorColumn                           none       weakSnail
-CursorLine                             none       weakSnail
-/16                                    none       weakSnail   underline
+CursorLine                             none       mistWhale
+/16                                    none       mistWhale   underline
 CursorLineNr                           none       none        bold
 /16                                    poorLlama  none
 debugBreakpoint                        soreSloth  gladRobin


### PR DESCRIPTION
<img width="360" height="54" alt="image" src="https://github.com/user-attachments/assets/f384b4aa-1092-4dc8-ad6d-d829edcf17c2" />

<img width="352" height="50" alt="image" src="https://github.com/user-attachments/assets/39dc28bf-a16b-4e3f-bd3e-d3f1733322da" />
